### PR TITLE
F2 pan length prefix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
                 <version>${version.maven-compiler-plugin}</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>

--- a/src/main/java/com/imohsenb/ISO8583/builders/BaseMessageClassBuilder.java
+++ b/src/main/java/com/imohsenb/ISO8583/builders/BaseMessageClassBuilder.java
@@ -92,6 +92,10 @@ public abstract class BaseMessageClassBuilder<T> implements
 
     @Override
     public DataElement<T> setField(FIELDS field, byte[] value) throws ISOException {
+        return setField(field,value,value.length);
+    }
+
+    public DataElement<T> setField(FIELDS field, byte[] value, int valueLength) throws ISOException {
 
         byte[] fValue = value;
 
@@ -142,10 +146,10 @@ public abstract class BaseMessageClassBuilder<T> implements
             switch (field.getFormat())
             {
                 case "LL":
-                    if(2 - String.valueOf(dLen).length() <= 0 )
-                        valueBuffer.prepend(StringUtil.hexStringToByteArray(dLen + ""));
+                    if(2 - String.valueOf(valueLength).length() <= 0 )
+                        valueBuffer.prepend(StringUtil.hexStringToByteArray(valueLength + ""));
                     else
-                        valueBuffer.prepend(StringUtil.hexStringToByteArray(String.format("%" + (2 - String.valueOf(dLen).length()) + "d%s", 0, dLen)));
+                        valueBuffer.prepend(StringUtil.hexStringToByteArray(String.format("%" + (2 - String.valueOf(valueLength).length()) + "d%s", 0, valueLength)));
                     break;
                 case "LLL":
                     valueBuffer.prepend(StringUtil.hexStringToByteArray(String.format("%0" + (4 - String.valueOf(dLen).length()) + "d%s", 0, dLen)));
@@ -199,10 +203,11 @@ public abstract class BaseMessageClassBuilder<T> implements
         switch (field.getType())
         {
             case "n":
-                setField(field,StringUtil.hexStringToByteArray(value));
+                setField(field,StringUtil.hexStringToByteArray(value),value.length());
                 break;
             default:
-                setField(field,value.getBytes());
+                byte[] bytes = value.getBytes();
+                setField(field,bytes,bytes.length);
         }
 
         return this;

--- a/src/main/java/com/imohsenb/ISO8583/entities/ISOMessage.java
+++ b/src/main/java/com/imohsenb/ISO8583/entities/ISOMessage.java
@@ -240,6 +240,7 @@ public class ISOMessage {
 
                 switch (field.getType()) {
                     case "z":
+                    case "n":
                         flen /= 2;
                 }
 

--- a/src/test/java/com/imohsenb/ISO8583/builders/GeneralMessageClassBuilderTest.java
+++ b/src/test/java/com/imohsenb/ISO8583/builders/GeneralMessageClassBuilderTest.java
@@ -66,4 +66,31 @@ public class GeneralMessageClassBuilderTest {
         //Then
         assertThat(isoMessage.toString()).isEqualTo("08002000000000000000920000");
     }
+
+
+    @Test
+    public void evenPanShouldHaveCorrectLengthPrefix() throws Exception {
+        ISOMessage isoMessage = ISOMessageBuilder.Packer(VERSION.V1987)
+                .networkManagement()
+                .setLeftPadding((byte) 0xF)
+                .mti(MESSAGE_FUNCTION.Request, MESSAGE_ORIGIN.Acquirer)
+                .processCode("920000")
+                .setField(FIELDS.F2_PAN, "1234567890123456")
+                .build();
+        System.out.println(isoMessage.toString());
+        assertThat(isoMessage.toString()).isEqualTo("08006000000000000000161234567890123456920000");
+    }
+
+    @Test
+    public void OddPanShouldHaveCorrectLengthPrefixAndPaddingChar() throws Exception {
+        ISOMessage isoMessage = ISOMessageBuilder.Packer(VERSION.V1987)
+                .networkManagement()
+                .setLeftPadding((byte) 0xF)
+                .mti(MESSAGE_FUNCTION.Request, MESSAGE_ORIGIN.Acquirer)
+                .processCode("920000")
+                .setField(FIELDS.F2_PAN, "1234567890123456789")
+                .build();
+        System.out.println(isoMessage.toString());
+        assertThat(isoMessage.toString()).isEqualTo("080060000000000000001901234567890123456789920000");
+    }
 }


### PR DESCRIPTION
Looking through the documentation it seems that the LLVAR prefix for numeric fields should be base on the number of digits, not the number of bytes.  It seems that the number of bytes is correct where the field isn't numeric.