### PR TITLE
F2 pan hex length prefix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
                 <version>${version.maven-compiler-plugin}</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>

--- a/src/main/java/com/imohsenb/ISO8583/builders/BaseMessageClassBuilder.java
+++ b/src/main/java/com/imohsenb/ISO8583/builders/BaseMessageClassBuilder.java
@@ -92,6 +92,10 @@ public abstract class BaseMessageClassBuilder<T> implements
 
     @Override
     public DataElement<T> setField(FIELDS field, byte[] value) throws ISOException {
+        return setField(field,value,value.length);
+    }
+
+    public DataElement<T> setField(FIELDS field, byte[] value, int valueLength) throws ISOException {
 
         byte[] fValue = value;
 
@@ -142,10 +146,10 @@ public abstract class BaseMessageClassBuilder<T> implements
             switch (field.getFormat())
             {
                 case "LL":
-                    if(2 - String.valueOf(dLen).length() <= 0 )
-                        valueBuffer.prepend(StringUtil.hexStringToByteArray(dLen + ""));
+                    if(2 - String.valueOf(valueLength).length() <= 0 )
+                        valueBuffer.prepend(StringUtil.hexStringToByteArray(valueLength + ""));
                     else
-                        valueBuffer.prepend(StringUtil.hexStringToByteArray(String.format("%" + (2 - String.valueOf(dLen).length()) + "d%s", 0, dLen)));
+                        valueBuffer.prepend(StringUtil.hexStringToByteArray(String.format("%" + (2 - String.valueOf(valueLength).length()) + "d%s", 0, valueLength)));
                     break;
                 case "LLL":
                     valueBuffer.prepend(StringUtil.hexStringToByteArray(String.format("%0" + (4 - String.valueOf(dLen).length()) + "d%s", 0, dLen)));
@@ -199,10 +203,11 @@ public abstract class BaseMessageClassBuilder<T> implements
         switch (field.getType())
         {
             case "n":
-                setField(field,StringUtil.hexStringToByteArray(value));
+                setField(field,StringUtil.hexStringToByteArray(value),value.length());
                 break;
             default:
-                setField(field,value.getBytes());
+                byte[] bytes = value.getBytes();
+                setField(field,bytes,bytes.length);
         }
 
         return this;

--- a/src/main/java/com/imohsenb/ISO8583/builders/BaseMessageClassBuilder.java
+++ b/src/main/java/com/imohsenb/ISO8583/builders/BaseMessageClassBuilder.java
@@ -27,6 +27,7 @@ public abstract class BaseMessageClassBuilder<T> implements
     private String messageFunction = "0";
     private String messageOrigin = "0";
     private String processCode;
+    private boolean hexLengthPrefix = false;
     private TreeMap<Integer,byte[]> dataElements = new TreeMap<>();
     private String header;
     private byte paddingByte = 0xF;
@@ -146,10 +147,15 @@ public abstract class BaseMessageClassBuilder<T> implements
             switch (field.getFormat())
             {
                 case "LL":
-                    if(2 - String.valueOf(valueLength).length() <= 0 )
-                        valueBuffer.prepend(StringUtil.hexStringToByteArray(valueLength + ""));
+                    String lengthPrefix =
+                            hexLengthPrefix
+                                    ? Integer.toHexString(valueLength)
+                                    : String.valueOf(valueLength);
+
+                    if (2 - String.valueOf(valueLength).length() <= 0)
+                        valueBuffer.prepend(StringUtil.hexStringToByteArray(lengthPrefix + ""));
                     else
-                        valueBuffer.prepend(StringUtil.hexStringToByteArray(String.format("%" + (2 - String.valueOf(valueLength).length()) + "d%s", 0, valueLength)));
+                        valueBuffer.prepend(StringUtil.hexStringToByteArray(String.format("%" + (2 - lengthPrefix.length()) + "d%s", 0, lengthPrefix)));
                     break;
                 case "LLL":
                     valueBuffer.prepend(StringUtil.hexStringToByteArray(String.format("%0" + (4 - String.valueOf(dLen).length()) + "d%s", 0, dLen)));
@@ -248,7 +254,16 @@ public abstract class BaseMessageClassBuilder<T> implements
         return this;
     }
 
-    //
+    public ProcessCode<T> useHexLengthPrefixes() {
+        hexLengthPrefix = true;
+        return this;
+    }
+
+    public ProcessCode<T> useBCDLengthPrefixes() {
+        hexLengthPrefix = false;
+        return this;
+    }
+
     public DataElement<T> processCode(String code) throws ISOException {
         this.processCode = code;
         this.setField(FIELDS.F3_ProcessCode,this.processCode);

--- a/src/main/java/com/imohsenb/ISO8583/builders/BaseMessageClassBuilder.java
+++ b/src/main/java/com/imohsenb/ISO8583/builders/BaseMessageClassBuilder.java
@@ -42,7 +42,7 @@ public abstract class BaseMessageClassBuilder<T> implements
     public ISOMessage build() throws ISOException {
 
         ISOMessage finalMessage = new ISOMessage();
-        finalMessage.setMessage(buildBuffer(true),this.header != null);
+        finalMessage.setMessage(buildBuffer(true),this.header != null, hexLengthPrefix);
 
         //clear();
 
@@ -208,6 +208,7 @@ public abstract class BaseMessageClassBuilder<T> implements
     public DataElement<T> setField(FIELDS field, String value) throws ISOException {
         switch (field.getType())
         {
+            case "a|n":
             case "n":
                 setField(field,StringUtil.hexStringToByteArray(value),value.length());
                 break;

--- a/src/main/java/com/imohsenb/ISO8583/entities/ISOMessage.java
+++ b/src/main/java/com/imohsenb/ISO8583/entities/ISOMessage.java
@@ -240,6 +240,7 @@ public class ISOMessage {
 
                 switch (field.getType()) {
                     case "z":
+                    case "n":
                         flen /= 2;
                 }
 

--- a/src/main/java/com/imohsenb/ISO8583/interfaces/ProcessCode.java
+++ b/src/main/java/com/imohsenb/ISO8583/interfaces/ProcessCode.java
@@ -9,6 +9,9 @@ import com.imohsenb.ISO8583.exceptions.ISOException;
  * @author Mohsen Beiranvand
  */
 public interface ProcessCode<T> {
+    ProcessCode<T> useHexLengthPrefixes();
+    ProcessCode<T> useBCDLengthPrefixes();
+
     DataElement<T> processCode(String code) throws ISOException;
     DataElement<T> processCode(PC_TTC_100 ttc) throws ISOException;
     DataElement<T> processCode(PC_TTC_100 ttc, PC_ATC atcFrom, PC_ATC atcTo) throws ISOException;

--- a/src/test/java/com/imohsenb/ISO8583/builders/GeneralMessageClassBuilderTest.java
+++ b/src/test/java/com/imohsenb/ISO8583/builders/GeneralMessageClassBuilderTest.java
@@ -66,4 +66,31 @@ public class GeneralMessageClassBuilderTest {
         //Then
         assertThat(isoMessage.toString()).isEqualTo("08002000000000000000920000");
     }
+
+
+    @Test
+    public void evenPanShouldHaveCorrectLengthPrefix() throws Exception {
+        ISOMessage isoMessage = ISOMessageBuilder.Packer(VERSION.V1987)
+                .networkManagement()
+                .setLeftPadding((byte) 0xF)
+                .mti(MESSAGE_FUNCTION.Request, MESSAGE_ORIGIN.Acquirer)
+                .processCode("920000")
+                .setField(FIELDS.F2_PAN, "1234567890123456")
+                .build();
+        System.out.println(isoMessage.toString());
+        assertThat(isoMessage.toString()).isEqualTo("08006000000000000000161234567890123456920000");
+    }
+
+    @Test
+    public void OddPanShouldHaveCorrectLengthPrefixAndPaddingChar() throws Exception {
+        ISOMessage isoMessage = ISOMessageBuilder.Packer(VERSION.V1987)
+                .networkManagement()
+                .setLeftPadding((byte) 0xF)
+                .mti(MESSAGE_FUNCTION.Request, MESSAGE_ORIGIN.Acquirer)
+                .processCode("920000")
+                .setField(FIELDS.F2_PAN, "1234567890123456789")
+                .build();
+        System.out.println(isoMessage.toString());
+        assertThat(isoMessage.toString()).isEqualTo("080060000000000000001901234567890123456789920000");
+    }
 }

--- a/src/test/java/com/imohsenb/ISO8583/builders/GeneralMessageClassBuilderTest.java
+++ b/src/test/java/com/imohsenb/ISO8583/builders/GeneralMessageClassBuilderTest.java
@@ -93,4 +93,48 @@ public class GeneralMessageClassBuilderTest {
         System.out.println(isoMessage.toString());
         assertThat(isoMessage.toString()).isEqualTo("080060000000000000001901234567890123456789920000");
     }
+
+    @Test
+    public void shortPanShouldHaveCorrectHexLengthPrefix() throws Exception {
+        ISOMessage isoMessage = ISOMessageBuilder.Packer(VERSION.V1987)
+                .networkManagement()
+                .setLeftPadding((byte) 0xF)
+                .mti(MESSAGE_FUNCTION.Request, MESSAGE_ORIGIN.Acquirer)
+                .useHexLengthPrefixes()
+                .processCode("920000")
+                .setField(FIELDS.F2_PAN, "12345678")
+                .build();
+        System.out.println(isoMessage.toString());
+        assertThat(isoMessage.toString()).isEqualTo("080060000000000000000812345678920000");
+    }
+
+    @Test
+    public void evenPanShouldHaveCorrectHexLengthPrefix() throws Exception {
+        ISOMessage isoMessage = ISOMessageBuilder.Packer(VERSION.V1987)
+                .networkManagement()
+                .setLeftPadding((byte) 0xF)
+                .mti(MESSAGE_FUNCTION.Request, MESSAGE_ORIGIN.Acquirer)
+                .useHexLengthPrefixes()
+                .processCode("920000")
+                .setField(FIELDS.F2_PAN, "1234567890123456")
+                .build();
+        System.out.println(isoMessage.toString());
+        assertThat(isoMessage.toString()).isEqualTo("08006000000000000000101234567890123456920000");
+    }
+
+    @Test
+    public void OddPanShouldHaveCorrectHexLengthPrefixAndPaddingChar() throws Exception {
+        ISOMessage isoMessage = ISOMessageBuilder.Packer(VERSION.V1987)
+                .networkManagement()
+                .setLeftPadding((byte) 0xF)
+                .mti(MESSAGE_FUNCTION.Request, MESSAGE_ORIGIN.Acquirer)
+                .useHexLengthPrefixes()
+                .processCode("920000")
+                .setField(FIELDS.F2_PAN, "1234567890123456789")
+                .build();
+        System.out.println(isoMessage.toString());
+        assertThat(isoMessage.toString()).isEqualTo("080060000000000000001301234567890123456789920000");
+    }
+    //.useBCDLengthPrefixes()
+
 }

--- a/src/test/java/com/imohsenb/ISO8583/entities/ISOMessageTest.java
+++ b/src/test/java/com/imohsenb/ISO8583/entities/ISOMessageTest.java
@@ -1,0 +1,44 @@
+package com.imohsenb.ISO8583.entities;
+
+import com.imohsenb.ISO8583.enums.FIELDS;
+import com.imohsenb.ISO8583.utils.StringUtil;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ISOMessageTest {
+    @Test
+    public void MessageWithOddBcdLengthPanCanBeParsed() throws Exception {
+        ISOMessage isoMessage = new ISOMessage();
+        isoMessage.setMessage(StringUtil.hexStringToByteArray("080060000000000000001901234567890123456789920000"), false);
+        byte[] pan = isoMessage.getField(FIELDS.F2_PAN);
+
+        assertThat(pan).isEqualTo(StringUtil.hexStringToByteArray("01234567890123456789"));
+    }
+
+    @Test
+    public void MessageWithEvenBcdLengthPanCanBeParsed() throws Exception {
+        ISOMessage isoMessage = new ISOMessage();
+        isoMessage.setMessage(StringUtil.hexStringToByteArray("080060000000000000000812345678920000"), false);
+        byte[] pan = isoMessage.getField(FIELDS.F2_PAN);
+
+        assertThat(pan).isEqualTo(StringUtil.hexStringToByteArray("12345678"));
+    }
+
+    @Test
+    public void MessageWithOddHexLengthPanCanBeParsed() throws Exception {
+        ISOMessage isoMessage = new ISOMessage();
+        isoMessage.setMessage(StringUtil.hexStringToByteArray("080060000000000000001301234567890123456789920000"), false, true);
+        byte[] pan = isoMessage.getField(FIELDS.F2_PAN);
+
+        assertThat(pan).isEqualTo(StringUtil.hexStringToByteArray("01234567890123456789"));
+    }
+
+    @Test
+    public void MessageWithEvenHexLengthPanCanBeParsed() throws Exception {
+        ISOMessage isoMessage = new ISOMessage();
+        isoMessage.setMessage(StringUtil.hexStringToByteArray("080060000000000000000812345678920000"), false, true);
+        byte[] pan = isoMessage.getField(FIELDS.F2_PAN);
+
+        assertThat(pan).isEqualTo(StringUtil.hexStringToByteArray("12345678"));
+    }}


### PR DESCRIPTION
We're integrating with SVS who have decided that the LLVAR prefix should be expressed in Hexadecimal rather than BCD.  We've extended BaseMessageClassBuilder so that either can be used with BCD remaining the default.