### PR TITLE
Secondary bitmaps and a parsing fix

### DIFF
--- a/src/main/java/com/imohsenb/ISO8583/entities/ISOMessage.java
+++ b/src/main/java/com/imohsenb/ISO8583/entities/ISOMessage.java
@@ -241,7 +241,7 @@ public class ISOMessage {
                 switch (field.getType()) {
                     case "z":
                     case "n":
-                        flen /= 2;
+                        flen = flen / 2 + flen % 2;
                 }
 
                 offset = offset + formatLength;

--- a/src/main/java/com/imohsenb/ISO8583/enums/FIELDS.java
+++ b/src/main/java/com/imohsenb/ISO8583/enums/FIELDS.java
@@ -8,7 +8,7 @@ import java.util.Map;
  */
 public enum FIELDS {
 // |Field title                        |no  |type  |len  |fixed |format|
-    F1_Bitmap                           (1,  "b",   64,   true,  null),
+    F1_Bitmap                           (1,  "b",   8,    true,  null),
     F2_PAN                              (2,  "n",   19,   false, "LL"),
     F3_ProcessCode                      (3,  "n",   6,    true,  null),
     F4_AmountTransaction                (4,  "n",   12,   true,  null),
@@ -71,7 +71,8 @@ public enum FIELDS {
     F61_Reserved_Private                (61, "ans", 999,  false, "LLL"),
     F62_Reserved_Private                (62, "ans", 999,  false, "LLL"),
     F63_Reserved_Private                (63, "ans", 999,  false, "LLL"),
-    F64_MAC                             (64, "b",   16,   true,  null);
+    F64_MAC                             (64, "b",   16,   true,  null),
+    F70_Network_Management_Code         (70, "n",    3,   true,  null);
 
 
 

--- a/src/test/java/com/imohsenb/ISO8583/builders/GeneralMessageClassBuilderTest.java
+++ b/src/test/java/com/imohsenb/ISO8583/builders/GeneralMessageClassBuilderTest.java
@@ -6,6 +6,7 @@ import com.imohsenb.ISO8583.enums.MESSAGE_FUNCTION;
 import com.imohsenb.ISO8583.enums.MESSAGE_ORIGIN;
 import com.imohsenb.ISO8583.enums.VERSION;
 import com.imohsenb.ISO8583.exceptions.ISOException;
+import com.imohsenb.ISO8583.utils.StringUtil;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -93,4 +94,18 @@ public class GeneralMessageClassBuilderTest {
         System.out.println(isoMessage.toString());
         assertThat(isoMessage.toString()).isEqualTo("080060000000000000001901234567890123456789920000");
     }
+
+    @Test
+    public void AMessageWithASecondaryBitmapIsFormattedCorrectly() throws ISOException {
+        ISOMessage isoMessage = ISOMessageBuilder.Packer(VERSION.V1987)
+                .networkManagement()
+                .setLeftPadding((byte) 0x0)
+                .mti(MESSAGE_FUNCTION.Request, MESSAGE_ORIGIN.Acquirer)
+                .processCode("123456")
+                .setField(FIELDS.F70_Network_Management_Code, "310")
+                .build();
+        System.out.println(isoMessage.toString());
+        assertThat(isoMessage.toString()).isEqualTo("0800A00000000000000004000000000000001234560310");
+    }
 }
+

--- a/src/test/java/com/imohsenb/ISO8583/builders/ISOMessageParseTest.java
+++ b/src/test/java/com/imohsenb/ISO8583/builders/ISOMessageParseTest.java
@@ -24,4 +24,12 @@ public class ISOMessageParseTest {
 
         assertThat(isoMessage.getField(FIELDS.F2_PAN)).isEqualTo(StringUtil.hexStringToByteArray("01234567890123456789"));
     }
+
+    @Test
+    public void anExtendedFieldIsReadCorrectly() throws ISOException {
+        ISOMessage isoMessage = new ISOMessage();
+        isoMessage.setMessage(StringUtil.hexStringToByteArray("0800A00000000000000004000000000000001234560310"), false);
+
+        assertThat(isoMessage.getField(FIELDS.F70_Network_Management_Code)).isEqualTo(StringUtil.hexStringToByteArray("0310"));
+    }
 }

--- a/src/test/java/com/imohsenb/ISO8583/builders/ISOMessageParseTest.java
+++ b/src/test/java/com/imohsenb/ISO8583/builders/ISOMessageParseTest.java
@@ -1,0 +1,27 @@
+package com.imohsenb.ISO8583.builders;
+
+import com.imohsenb.ISO8583.entities.ISOMessage;
+import com.imohsenb.ISO8583.enums.FIELDS;
+import com.imohsenb.ISO8583.exceptions.ISOException;
+import com.imohsenb.ISO8583.utils.StringUtil;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ISOMessageParseTest {
+    @Test
+    public void anEvenLengthPanIsParsedCorrectly() throws Exception {
+        ISOMessage isoMessage = new ISOMessage();
+        isoMessage.setMessage(StringUtil.hexStringToByteArray("08006000000000000000161234567890123456920000"), false);
+
+        assertThat(isoMessage.getField(FIELDS.F2_PAN)).isEqualTo(StringUtil.hexStringToByteArray("1234567890123456"));
+    }
+
+    @Test
+    public void anOddLengthPanIsParsedCorrectly() throws Exception {
+        ISOMessage isoMessage = new ISOMessage();
+        isoMessage.setMessage(StringUtil.hexStringToByteArray("080060000000000000001901234567890123456789920000"), false);
+
+        assertThat(isoMessage.getField(FIELDS.F2_PAN)).isEqualTo(StringUtil.hexStringToByteArray("01234567890123456789"));
+    }
+}


### PR DESCRIPTION
Odd length BCD LLVAR fields parse correctly
Secondary bitmaps are supported.